### PR TITLE
fix: use proper config in confirm_deletion

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -7,6 +7,7 @@ local action_set = require('telescope.actions.set')
 local action_state = require('telescope.actions.state')
 local conf = require('telescope.config').values
 local git_worktree = require('git-worktree')
+local Config = require('git-worktree.config')
 
 local force_next_deletion = false
 
@@ -70,7 +71,7 @@ end
 -- @param forcing boolean: whether the deletion is forced
 -- @return boolean: whether the deletion is confirmed
 local confirm_deletion = function(forcing)
-    if not git_worktree._config.confirm_telescope_deletions then
+    if not Config.confirm_telescope_deletions then
         return true
     end
 


### PR DESCRIPTION
The Telescope extension had the following error without this patch:

```
E5108: Error executing lua: ...ree.nvim/main/lua/telescope/_extensions/git_worktree.lua:73: attempt to index field '_config' (a
 nil value)                                                                                                                    
stack traceback:                                                                                                               
        ...ree.nvim/main/lua/telescope/_extensions/git_worktree.lua:73: in function 'confirm_deletion'                         
        ...ree.nvim/main/lua/telescope/_extensions/git_worktree.lua:91: in function 'key_func'                                 
        ...hare/nvim/lazy/telescope.nvim/lua/telescope/mappings.lua:253: in function <...hare/nvim/lazy/telescope.nvim/lua/tele
scope/mappings.lua:252>
```