### PR TITLE
[RFC] Set --track when creating a worktree

### DIFF
--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -108,11 +108,17 @@ function M.toplevel_dir()
     return table.concat(stdout, '')
 end
 
-function M.has_branch(branch, cb)
+function M.has_branch(branch, remotes, cb)
     local found = false
+
+    local args = { 'branch' }
+    if remotes then
+        table.insert(args, '--remotes')
+    end
+
     local job = Job:new {
         command = 'git',
-        args = { 'branch' },
+        args = args,
         on_stdout = function(_, data)
             -- remove  markere on current branch
             data = data:gsub('*', '')
@@ -131,8 +137,10 @@ end
 --- @param path string
 --- @param branch string
 --- @param found_branch boolean
+--- @param upstream string
+--- @param found_upstream boolean
 --- @return Job
-function M.create_worktree_job(path, branch, found_branch)
+function M.create_worktree_job(path, branch, found_branch, upstream, found_upstream)
     local worktree_add_cmd = 'git'
     local worktree_add_args = { 'worktree', 'add' }
 
@@ -143,6 +151,11 @@ function M.create_worktree_job(path, branch, found_branch)
     else
         table.insert(worktree_add_args, path)
         table.insert(worktree_add_args, branch)
+    end
+
+    if found_upstream then
+        table.insert(worktree_add_args, '--track')
+        table.insert(worktree_add_args, upstream)
     end
 
     return Job:new {

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -7,6 +7,7 @@ local action_set = require('telescope.actions.set')
 local action_state = require('telescope.actions.state')
 local conf = require('telescope.config').values
 local git_worktree = require('git-worktree')
+local Config = require('git-worktree.config')
 
 local force_next_deletion = false
 
@@ -70,7 +71,7 @@ end
 -- @param forcing boolean: whether the deletion is forced
 -- @return boolean: whether the deletion is confirmed
 local confirm_deletion = function(forcing)
-    if not git_worktree._config.confirm_telescope_deletions then
+    if not Config.confirm_telescope_deletions then
         return true
     end
 


### PR DESCRIPTION
This PR is not to be merged because it is based off these other two: https://github.com/polarmutex/git-worktree.nvim/pull/18 https://github.com/polarmutex/git-worktree.nvim/pull/19

Basically, instead of using git-branch with --set-upstream-to after creating a worktree, the plugin should simply use git-worktree --track instead. That would simplify things a lot for the case [where upstream ~= nil in worktree.lua](https://github.com/polarmutex/git-worktree.nvim/blob/main/lua/git-worktree/worktree.lua#L112).  I wanted to ask you what do you think the best approach should be here.

Thanks,