### PR TITLE
Fix invalid get() invocation for builtin hooks

### DIFF
--- a/lua/git-worktree/hooks.lua
+++ b/lua/git-worktree/hooks.lua
@@ -59,15 +59,14 @@ local Path = require('plenary.path')
 M.builtins = {
     ---@type git-worktree.hooks.cb.switch
     update_current_buffer_on_switch = function(_, prev_path)
+        local config = require('git-worktree.config')
         if prev_path == nil then
-            local config = require('git-worktree.config').get()
             vim.cmd(config.update_on_change_command)
         end
 
         local cwd = vim.loop.cwd()
         local current_buf_name = vim.api.nvim_buf_get_name(0)
         if not current_buf_name or current_buf_name == '' then
-            local config = require('git-worktree.config').get()
             vim.cmd(config.update_on_change_command)
         end
 
@@ -79,7 +78,6 @@ M.builtins = {
 
         local start, fin = string.find(name, prev_path, 1, true)
         if start == nil then
-            local config = require('git-worktree.config').get()
             vim.cmd(config.update_on_change_command)
         end
 
@@ -88,7 +86,6 @@ M.builtins = {
         local final_path = Path:new({ cwd, local_name }):absolute()
 
         if not Path:new(final_path):exists() then
-            local config = require('git-worktree.config').get()
             vim.cmd(config.update_on_change_command)
         end
 

--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -7,6 +7,14 @@
 ---
 ---@mod git-worktree
 
+---@mod git-worktree.telescope
+---@brief [[
+--- To get telescope-file-browser loaded and working with telescope,
+--- you need to call load_extension, somewhere after setup function:
+--- <code>
+--- require("telescope").load_extension("git_worktree")
+---@brief ]]
+
 ---@brief [[
 ---@brief ]]
 

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -195,9 +195,10 @@ local telescope_git_worktree = function(opts)
     }
 
     local make_display = function(entry)
+        local path, _ = utils.transform_path(opts, entry.path)
         return displayer {
             { entry.branch, 'TelescopeResultsIdentifier' },
-            { utils.transform_path(opts, entry.path) },
+            { path },
             { entry.sha },
         }
     end


### PR DESCRIPTION
https://github.com/polarmutex/git-worktree.nvim/commit/f37e1a2f020f4c788d1b0cf8d1462a640783cfb3#diff-8c3e398fc7377f10e5b7c253c3fa3954c027b4cab0960566faae41277f53fa1aL40 removed the get() function and cleaned up most references to it except for hooks.lua

Without this patch updating the current buffer (especially if empty) fails
```
Error executing vim.schedule lua callback: ...e/nvim/lazy/git-worktree.nvim/lua/git-worktree/hooks.lua:70: attempt
to call field 'get' (a nil value)
stack traceback:
        ...e/nvim/lazy/git-worktree.nvim/lua/git-worktree/hooks.lua:70: in function 'hook'
        ...e/nvim/lazy/git-worktree.nvim/lua/git-worktree/hooks.lua:43: in function 'emit'
        ...vim/lazy/git-worktree.nvim/lua/git-worktree/worktree.lua:74: in function <...vim/lazy/git-worktree.nvim/
lua/git-worktree/worktree.lua:72>
```