### PR TITLE
Add prefix and branch name as default for worktree path

### DIFF
--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -106,8 +106,9 @@ end
 -- Create a prompt to get the path of the new worktree
 -- @param cb function: the callback to call with the path
 -- @return nil
-local create_input_prompt = function(cb)
-    local subtree = vim.fn.input('Path to subtree > ')
+local create_input_prompt = function(cb, name, prefix)
+    prefix = prefix or ''
+    local subtree = vim.fn.input('Path to subtree > ', prefix .. name)
     cb(subtree)
 end
 
@@ -134,7 +135,7 @@ local create_worktree = function(opts)
                     name = branch
                 end
                 git_worktree.create_worktree(name, branch)
-            end)
+            end, branch, opts.prefix)
         end)
 
         return true


### PR DESCRIPTION
This will by default use the branch name when asking for the path of the new worktree.
And by using `opt.prefix` it allows to create the worktree at the preferred location. 

Solves #15 at least for me using it like:  
`lua require('telescope').extensions.git_worktree.create_git_worktree({prefix='../'})`