### PR TITLE
Enable upstream tracking

### DIFF
--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -113,20 +113,16 @@ end
 
 function M.has_branch(branch, opts, cb)
     local found = false
-    local args = { 'branch' }
+    local args = { 'branch', '--format=%(refname:short)' }
     opts = opts or {}
-    for i = 1, #opts do
-        args[i+1] = opts[i]
+    for _, opt in ipairs(opts) do
+        args[#args + 1] = opt
     end
 
     local job = Job:new {
         command = 'git',
         args = args,
         on_stdout = function(_, data)
-            -- remove marker on current branch
-            data = data:gsub('*', '')
-            data = data:gsub('remotes/', '')
-            data = vim.trim(data)
             found = found or data == branch
         end,
         cwd = vim.loop.cwd(),

--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -135,7 +135,7 @@ function M.has_branch(branch, opts, cb)
 end
 
 --- @param path string
---- @param branch string
+--- @param branch string?
 --- @param found_branch boolean
 --- @param upstream string
 --- @param found_upstream boolean
@@ -144,18 +144,23 @@ function M.create_worktree_job(path, branch, found_branch, upstream, found_upstr
     local worktree_add_cmd = 'git'
     local worktree_add_args = { 'worktree', 'add' }
 
-    if not found_branch then
-        table.insert(worktree_add_args, '-b')
-        table.insert(worktree_add_args, branch)
+    if branch == nil then
+        table.insert(worktree_add_args, '-d')
         table.insert(worktree_add_args, path)
-
-        if found_upstream and branch ~= upstream then
-            table.insert(worktree_add_args, '--track')
-            table.insert(worktree_add_args, upstream)
-        end
     else
-        table.insert(worktree_add_args, path)
-        table.insert(worktree_add_args, branch)
+        if not found_branch then
+            table.insert(worktree_add_args, '-b')
+            table.insert(worktree_add_args, branch)
+            table.insert(worktree_add_args, path)
+
+            if found_upstream and branch ~= upstream then
+                table.insert(worktree_add_args, '--track')
+                table.insert(worktree_add_args, upstream)
+            end
+        else
+            table.insert(worktree_add_args, path)
+            table.insert(worktree_add_args, branch)
+        end
     end
 
     return Job:new {

--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -8,41 +8,44 @@ local M = {}
 -- A lot of this could be cleaned up if there was better job -> job -> function
 -- communication.  That should be doable here in the near future
 ---
----@param path_str string path to the worktree to check. if relative, then path from the git root dir
+---@param path_str string path to the worktree to check
+---@param branch string? branch the worktree is associated with
 ---@param cb any
-function M.has_worktree(path_str, cb)
+function M.has_worktree(path_str, branch, cb)
     local found = false
-    local path = Path:new(path_str)
+    local path
 
     if path_str == '.' then
         path_str = vim.loop.cwd()
-        path = Path:new(path_str)
     end
+
+    path = Path:new(path_str)
+    if not path:is_absolute() then
+        path = Path:new(string.format('%s' .. Path.path.sep .. '%s', vim.loop.cwd(), path_str))
+    end
+    path = path:absolute()
+
+    Log.debug('has_worktree: %s %s', path, branch)
 
     local job = Job:new {
         command = 'git',
-        args = { 'worktree', 'list' },
-        on_stdout = function(_, data)
-            local list_data = {}
-            for section in data:gmatch('%S+') do
-                table.insert(list_data, section)
+        args = { 'worktree', 'list', '--porcelain' },
+        on_stdout = function(_, line)
+            if line:match('^worktree ') then
+                local current_worktree = Path:new(line:match('^worktree (.+)$')):absolute()
+                Log.debug('current_worktree: "%s"', current_worktree)
+                if path == current_worktree then
+                    found = true
+                    return
+                end
+            elseif branch ~= nil and line:match('^branch ') then
+                local worktree_branch = line:match('^branch (.+)$')
+                Log.debug('worktree_branch: %s', worktree_branch)
+                if worktree_branch == 'refs/heads/' .. branch then
+                    found = true
+                    return
+                end
             end
-
-            data = list_data[1]
-
-            local start
-            if path:is_absolute() then
-                start = data == path_str
-            else
-                local worktree_path = Path:new(string.format('%s' .. Path.path.sep .. '%s', vim.loop.cwd(), path_str))
-                worktree_path = worktree_path:absolute()
-                start = data == worktree_path
-            end
-
-            -- TODO: This is clearly a hack (do not think we need this anymore?)
-            --local start_with_head = string.find(data, string.format('[heads/%s]', path), 1, true)
-            found = found or start
-            Log.debug('found: %s', found)
         end,
         cwd = vim.loop.cwd(),
     }
@@ -108,14 +111,21 @@ function M.toplevel_dir()
     return table.concat(stdout, '')
 end
 
-function M.has_branch(branch, cb)
+function M.has_branch(branch, opts, cb)
     local found = false
+    local args = { 'branch' }
+    opts = opts or {}
+    for i = 1, #opts do
+        args[i+1] = opts[i]
+    end
+
     local job = Job:new {
         command = 'git',
-        args = { 'branch' },
+        args = args,
         on_stdout = function(_, data)
-            -- remove  markere on current branch
+            -- remove marker on current branch
             data = data:gsub('*', '')
+            data = data:gsub('remotes/', '')
             data = vim.trim(data)
             found = found or data == branch
         end,
@@ -131,8 +141,10 @@ end
 --- @param path string
 --- @param branch string
 --- @param found_branch boolean
+--- @param upstream string
+--- @param found_upstream boolean
 --- @return Job
-function M.create_worktree_job(path, branch, found_branch)
+function M.create_worktree_job(path, branch, found_branch, upstream, found_upstream)
     local worktree_add_cmd = 'git'
     local worktree_add_args = { 'worktree', 'add' }
 
@@ -140,6 +152,11 @@ function M.create_worktree_job(path, branch, found_branch)
         table.insert(worktree_add_args, '-b')
         table.insert(worktree_add_args, branch)
         table.insert(worktree_add_args, path)
+
+        if found_upstream and branch ~= upstream then
+            table.insert(worktree_add_args, '--track')
+            table.insert(worktree_add_args, upstream)
+        end
     else
         table.insert(worktree_add_args, path)
         table.insert(worktree_add_args, branch)
@@ -195,7 +212,7 @@ end
 --- @return Job
 function M.setbranch_job(path, branch, upstream)
     local set_branch_cmd = 'git'
-    local set_branch_args = { 'branch', string.format('--set-upstream-to=%s/%s', upstream, branch) }
+    local set_branch_args = { 'branch', branch, string.format('--set-upstream-to=%s', upstream) }
     return Job:new {
         command = set_branch_cmd,
         args = set_branch_args,

--- a/lua/git-worktree/init.lua
+++ b/lua/git-worktree/init.lua
@@ -23,7 +23,7 @@ local M = {}
 local Worktree = require('git-worktree.worktree')
 
 --Switch the current worktree
----@param path string
+---@param path string?
 function M.switch_worktree(path)
     Worktree.switch(path)
 end

--- a/lua/git-worktree/worktree.lua
+++ b/lua/git-worktree/worktree.lua
@@ -42,6 +42,7 @@ local function change_dirs(path)
         vim.cmd('clearjumps')
     end
 
+    print(string.format('Switched to %s', path))
     return previous_worktree
 end
 
@@ -73,11 +74,6 @@ local M = {}
 function M.switch(path)
     if path == nil then
         change_dirs(path)
-        -- TODO: do we need to send an event when getting out of a tree?
-        -- vim.schedule(function()
-        --     local prev_path = change_dirs(path)
-        --     Hooks.emit(Hooks.type.SWITCH, path, prev_path)
-        -- end)
     else
         if path == vim.loop.cwd() then
             return

--- a/lua/git-worktree/worktree.lua
+++ b/lua/git-worktree/worktree.lua
@@ -113,6 +113,19 @@ function M.create(path, branch, upstream)
             return
         end
 
+        if branch == '' then
+            -- detached head
+            local create_wt_job = Git.create_worktree_job(path, nil, false, nil, false)
+            create_wt_job:after(function()
+                vim.schedule(function()
+                    Hooks.emit(Hooks.type.CREATE, path, branch, upstream)
+                    M.switch(path)
+                end)
+            end)
+            create_wt_job:start()
+            return
+        end
+
         Git.has_branch(branch, { '--remotes' }, function(found_remote_branch)
             Log.debug('Found remote branch %s? %s', branch, found_remote_branch)
             if found_remote_branch then

--- a/lua/git-worktree/worktree.lua
+++ b/lua/git-worktree/worktree.lua
@@ -67,7 +67,11 @@ function M.switch(path)
         if not found then
             Log.error('worktree does not exists, please create it first %s ', path)
         end
-        Log.debug('has worktree')
+        Git.has_worktree(path, nil, function(found)
+            if not found then
+                Log.error('Worktree does not exists, please create it first %s ', path)
+                return
+            end
 
         vim.schedule(function()
             local prev_path = change_dirs(path)
@@ -78,7 +82,7 @@ end
 
 --- CREATE ---
 
---crerate a worktree
+--create a worktree
 ---@param path string
 ---@param branch string
 ---@param upstream? string
@@ -91,67 +95,32 @@ function M.create(path, branch, upstream)
 
     -- M.setup_git_info()
 
-    Git.has_worktree(path, function(found)
+    Git.has_worktree(path, branch, function(found)
         if found then
-            Log.error('worktree already exists')
+            Log.error('Path "%s" or branch "%s" already in use.', path, branch)
             return
         end
 
-        Git.has_branch(branch, function(found_branch)
-            Config = require('git-worktree.config')
-            local worktree_path
-            if Path:new(path):is_absolute() then
-                worktree_path = path
-            else
-                worktree_path = Path:new(vim.loop.cwd(), path):absolute()
-            end
+        Git.has_branch(branch, nil, function(found_branch)
+            Git.has_branch(upstream, { '--all' }, function(found_upstream)
+                local create_wt_job = Git.create_worktree_job(path, branch, found_branch, upstream, found_upstream)
 
-            -- create_worktree(path, branch, upstream, found_branch)
-            local create_wt_job = Git.create_worktree_job(path, branch, found_branch)
-
-            if upstream ~= nil then
-                local fetch = Git.fetchall_job(path, branch, upstream)
-                local set_branch = Git.setbranch_job(path, branch, upstream)
-                local set_push = Git.setpush_job(path, branch, upstream)
-                local rebase = Git.rebase_job(path)
-
-                create_wt_job:and_then_on_success(fetch)
-                fetch:and_then_on_success(set_branch)
-
-                if Config.autopush then
-                    -- These are "optional" operations.
-                    -- We have to figure out how we want to handle these...
-                    set_branch:and_then(set_push)
-                    set_push:and_then(rebase)
-                    set_push:after_failure(failure('create_worktree', set_branch.args, worktree_path, true))
-                else
-                    set_branch:and_then(rebase)
+                Log.debug('Found branch %s? %s', branch, found_branch)
+                Log.debug('Found upstream %s? %s', upstream, found_upstream)
+                if found_branch and found_upstream and branch ~= upstream then
+                    local set_remote = Git.setbranch_job(path, branch, upstream)
+                    create_wt_job:and_then_on_success(set_remote)
                 end
 
-                create_wt_job:after_failure(failure('create_worktree', create_wt_job.args, vim.loop.cwd()))
-                fetch:after_failure(failure('create_worktree', fetch.args, worktree_path))
-
-                set_branch:after_failure(failure('create_worktree', set_branch.args, worktree_path, true))
-
-                rebase:after(function()
-                    if rebase.code ~= 0 then
-                        Log.devel("Rebase failed, but that's ok.")
-                    end
-
-                    vim.schedule(function()
-                        Hooks.emit(Hooks.type.CREATE, path, branch, upstream)
-                        M.switch(path)
-                    end)
-                end)
-            else
                 create_wt_job:after(function()
                     vim.schedule(function()
                         Hooks.emit(Hooks.type.CREATE, path, branch, upstream)
                         M.switch(path)
                     end)
                 end)
-            end
-            create_wt_job:start()
+
+                create_wt_job:start()
+            end)
         end)
     end)
 end
@@ -167,12 +136,10 @@ function M.delete(path, force, opts)
         opts = {}
     end
 
-    Git.has_worktree(path, function(found)
-        Log.info('OMG here')
+    Git.has_worktree(path, nil, function(found)
         if not found then
             Log.error('Worktree %s does not exist', path)
-        else
-            Log.info('Worktree %s does exist', path)
+            return
         end
 
         local delete = Git.delete_worktree_job(path, force)

--- a/lua/git-worktree/worktree.lua
+++ b/lua/git-worktree/worktree.lua
@@ -156,6 +156,8 @@ function M.delete(path, force, opts)
         opts = {}
     end
 
+    local branch = Git.parse_head(path)
+
     Git.has_worktree(path, nil, function(found)
         if not found then
             Log.error('Worktree %s does not exist', path)
@@ -167,7 +169,7 @@ function M.delete(path, force, opts)
             Log.info('delete after success')
             Hooks.emit(Hooks.type.DELETE, path)
             if opts.on_success then
-                opts.on_success()
+                opts.on_success({ branch = branch })
             end
         end))
 

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -281,8 +281,8 @@ local telescope_git_worktree = function(opts)
                 map('n', '<m-c>', function()
                     telescope_create_worktree {}
                 end)
-                map('i', '<c-d>', delete_worktree)
-                map('n', '<c-d>', delete_worktree)
+                map('i', '<m-d>', delete_worktree)
+                map('n', '<m-d>', delete_worktree)
                 map('i', '<c-f>', toggle_forced_deletion)
                 map('n', '<c-f>', toggle_forced_deletion)
 

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -237,9 +237,9 @@ local telescope_git_worktree = function(opts)
         parse_line(line)
     end
 
-    if #results == 0 then
-        return
-    end
+    -- if #results == 0 then
+    --     return
+    -- end
 
     local displayer = require('telescope.pickers.entry_display').create {
         separator = ' ',
@@ -275,6 +275,12 @@ local telescope_git_worktree = function(opts)
             attach_mappings = function(_, map)
                 action_set.select:replace(switch_worktree)
 
+                map('i', '<m-c>', function()
+                    telescope_create_worktree {}
+                end)
+                map('n', '<m-c>', function()
+                    telescope_create_worktree {}
+                end)
                 map('i', '<c-d>', delete_worktree)
                 map('n', '<c-d>', delete_worktree)
                 map('i', '<c-f>', toggle_forced_deletion)

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -16,6 +16,9 @@ local force_next_deletion = false
 -- @return string: the path of the selected worktree
 local get_worktree_path = function(prompt_bufnr)
     local selection = action_state.get_selected_entry(prompt_bufnr)
+    if selection == nil then
+        return
+    end
     return selection.path
 end
 
@@ -25,9 +28,11 @@ end
 local switch_worktree = function(prompt_bufnr)
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
-    if worktree_path ~= nil then
-        git_worktree.switch_worktree(worktree_path)
+    if worktree_path == nil then
+        vim.print("No worktree selected")
+        return
     end
+    git_worktree.switch_worktree(worktree_path)
 end
 
 -- Toggle the forced deletion of the next worktree
@@ -93,6 +98,8 @@ local delete_worktree = function(prompt_bufnr)
         return
     end
 
+    git_worktree.switch_worktree(nil)
+
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
     if worktree_path ~= nil then
@@ -139,6 +146,8 @@ end
 -- @param opts table: the options for the telescope picker (optional)
 -- @return nil
 local create_worktree = function(opts)
+    git_worktree.switch_worktree(nil)
+
     opts = opts or {}
     -- TODO: Parse this as an user option.
     -- opts.pattern = 'refs/heads' -- only show local branches

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -145,7 +145,7 @@ end
 -- Create a worktree
 -- @param opts table: the options for the telescope picker (optional)
 -- @return nil
-local create_worktree = function(opts)
+local telescope_create_worktree = function(opts)
     git_worktree.switch_worktree(nil)
 
     opts = opts or {}
@@ -291,6 +291,6 @@ end
 return require('telescope').register_extension {
     exports = {
         git_worktree = telescope_git_worktree,
-        create_git_worktree = create_worktree,
+        create_git_worktree = telescope_create_worktree,
     },
 }

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -28,11 +28,11 @@ end
 -- @return nil
 local switch_worktree = function(prompt_bufnr)
     local worktree_path = get_worktree_path(prompt_bufnr)
-    actions.close(prompt_bufnr)
     if worktree_path == nil then
         vim.print('No worktree selected')
         return
     end
+    actions.close(prompt_bufnr)
     git_worktree.switch_worktree(worktree_path)
 end
 

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -122,6 +122,14 @@ local create_input_prompt = function(opts, cb)
     local branches = vim.fn.systemlist('git branch --all')
     if #branches == 0 then
         cb(path, nil)
+        return
+    end
+
+    local re = string.format('git branch --remotes --list %s', opts.branch)
+    local remote_branch = vim.fn.systemlist(re)
+    if #remote_branch == 1 then
+        cb(path, nil)
+        return
     end
 
     local confirmed = vim.fn.input('Track an upstream? [y/n]: ')
@@ -147,10 +155,7 @@ end
 -- @return nil
 local telescope_create_worktree = function(opts)
     git_worktree.switch_worktree(nil)
-
     opts = opts or {}
-    -- TODO: Parse this as an user option.
-    -- opts.pattern = 'refs/heads' -- only show local branches
 
     -- TODO: Enable detached HEAD worktree creation, but for this the telescope
     -- picker git_branches must show refs/tags.

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -29,7 +29,7 @@ local switch_worktree = function(prompt_bufnr)
     local worktree_path = get_worktree_path(prompt_bufnr)
     actions.close(prompt_bufnr)
     if worktree_path == nil then
-        vim.print("No worktree selected")
+        vim.print('No worktree selected')
         return
     end
     git_worktree.switch_worktree(worktree_path)
@@ -52,6 +52,7 @@ end
 -- Handler for successful deletion
 -- @return nil
 local delete_success_handler = function()
+    print('Deleted worktree')
     force_next_deletion = false
 end
 


### PR DESCRIPTION
As previously discussed in PR [20](https://github.com/polarmutex/git-worktree.nvim/pull/20) and now mentioned in issue [30](https://github.com/polarmutex/git-worktree.nvim/issues/30), dealing with remote tracking trees currently does not have a good user experience. This pull request addresses this, while also adding a necessary feature to make that experience even smoother: switching directories back to the bare repository. Finally, a few minor fixes.

There are still some rough edges mentioned in some new TODOs and other minor stuff like properly announcing when the jobs ended, but those can be addressed later.