### PR TITLE
fix: Stop using "local/" for upstream tracking disambiguation

### DIFF
--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -153,7 +153,7 @@ function M.create_worktree_job(path, branch, found_branch, upstream, found_upstr
             table.insert(worktree_add_args, branch)
             table.insert(worktree_add_args, path)
 
-            if found_upstream and branch ~= upstream then
+            if found_upstream then
                 table.insert(worktree_add_args, '--track')
                 table.insert(worktree_add_args, upstream)
             end

--- a/lua/telescope/_extensions/git_worktree.lua
+++ b/lua/telescope/_extensions/git_worktree.lua
@@ -158,7 +158,7 @@ local create_input_prompt = function(opts, cb)
     local re = string.format('git branch --remotes --list %s', opts.branch)
     local remote_branch = vim.fn.systemlist(re)
     if #remote_branch == 1 then
-        cb(path, nil)
+        cb(path, opts.branch)
         return
     end
 
@@ -191,6 +191,9 @@ local telescope_create_worktree = function(opts)
         -- if current_line is still not enough to filter everything but user
         -- still wants to use it as the new branch name, without selecting anything
         local branch = action_state.get_current_line()
+        -- if branch == "" then
+        --     TODO:detached head should list tags
+        -- end
         actions.close(prompt_bufnr)
         opts.branch = branch
         create_input_prompt(opts, function(path, upstream)


### PR DESCRIPTION
Instead, use the strategy that git adopts, i.e.:

`git worktree add -b upstream_branch path remote/upstream_branch`

If there's already a branch with the same name, it will fail and the user should be able to choose a new name and track the same upstream_branch when using the Telescope extension.