### PR TITLE
Fixes

### DIFF
--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -278,6 +278,29 @@ function M.parse_head(path)
     return table.concat(stdout, '')
 end
 
+--- @param path string
+--- @return string|nil
+function M.current_branch(path)
+    local job = Job:new {
+        command = 'git',
+        args = { 'branch', '--show-current' },
+        cwd = path,
+        on_start = function()
+            Log.debug('git branch --show-current')
+        end,
+    }
+
+    local stdout, code = job:sync()
+    if code ~= 0 then
+        Log.error(
+            'Error in getting current branch: code:' .. tostring(code) .. ' out: ' .. table.concat(stdout, '') .. '.'
+        )
+        return nil
+    end
+
+    return table.concat(stdout, '')
+end
+
 --- @param branch string
 --- @return Job|nil
 function M.delete_branch_job(branch)

--- a/lua/git-worktree/git.lua
+++ b/lua/git-worktree/git.lua
@@ -113,7 +113,7 @@ end
 
 function M.has_branch(branch, opts, cb)
     local found = false
-    local args = { 'branch', '--format=%(refname:short)' }
+    local args = { 'branch', '--format=%(refname)' }
     opts = opts or {}
     for _, opt in ipairs(opts) do
         args[#args + 1] = opt
@@ -123,7 +123,8 @@ function M.has_branch(branch, opts, cb)
         command = 'git',
         args = args,
         on_stdout = function(_, data)
-            found = found or data == branch
+            local current = data:match('^refs/heads/(.+)') or data:match('^refs/remotes/(.+)')
+            found = found or current == branch
         end,
         cwd = vim.loop.cwd(),
     }

--- a/lua/git-worktree/worktree.lua
+++ b/lua/git-worktree/worktree.lua
@@ -169,7 +169,7 @@ function M.delete(path, force, opts)
         opts = {}
     end
 
-    local branch = Git.parse_head(path)
+    local branch = Git.current_branch(path)
 
     Git.has_worktree(path, nil, function(found)
         if not found then


### PR DESCRIPTION
- Add a few debug lines
- Add a new current_branch() so ambiguos refs won't be a problem if the user chooses to delete a branch after deleting a tree
- Don't use refname:short in has_branch because ambiguous short names are prepended by "heads/" in `git branch` (e.g. if there's a branch with the same name of a tag)